### PR TITLE
Tabs: Fix tab title underline color

### DIFF
--- a/careers/blocks/tabs/tabs.css
+++ b/careers/blocks/tabs/tabs.css
@@ -151,7 +151,7 @@
     padding-bottom: var(--layout-size-xs);
     border-bottom: 3px solid;
     margin: -3px auto 0;
-    border-color: var(--static-color-black);
+    border-color: var(--block-background-color);
   }
 
   .tabs.block .tab-title:hover::after {


### PR DESCRIPTION
<!--- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

Fix #<gh-issue-id>

## 🔗 Test URLs:

- Before: https://main--caesars-careers--hlxsites.hlx.page/apply
- After: https://tabs-css-fix--caesars-careers--hlxsites.hlx.page/apply

## 📝 Description:

<!--- What changes are in this pull request? Include screenshots when helpful. -->
- Fix tab title underline color (to use the "block background color" from theming)