### PR TITLE
updating fstab to point to parent folder

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/sites/caesars/careers
+  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/sites/caesars


### PR DESCRIPTION

Fix #82 

## 🔗 Test URLs:

- Before: https://main--caesars-careers--hlxsites.hlx.page/careers/
- After: https://update-fstab--caesars-careers--hlxsites.hlx.page/careers/

## 📝 Description:
Updating fstab to point to parent folder to make it easy for CDN to redirect the /careers* path to Franklin